### PR TITLE
Add support for passing in private key

### DIFF
--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -58,7 +58,7 @@ export const state: State = {
 
 interface Web3ConnectionProps {
   type: "web3";
-  web3Connection: any;
+  web3Connection: ethers.providers.ExternalProvider;
 }
 
 interface PrivateKeyProps {


### PR DESCRIPTION
Currently, setProvider only accepts a browser web3 connection so the SDK can only be used in the browser. 

This PR adds an option for passing in a private key and chainId to setProvider, allowing the SDK to be used in backend/custodial products.  

Tested by passing in a private key from the frontend 

https://user-images.githubusercontent.com/10327933/235494216-7b332c2e-6e53-4294-8442-824c7c76e263.mov

