### PR TITLE
Almaraz/hook library

### DIFF
--- a/contracts/src/interfaces/IHooks.sol
+++ b/contracts/src/interfaces/IHooks.sol
@@ -15,14 +15,14 @@ interface IHooks {
         NotaState calldata nota,
         uint256 instant,
         bytes calldata hookData
-    ) external returns (uint256);
+    ) external returns (bytes4, uint256);
 
     function beforeTransfer(
         address caller,
         NotaState calldata nota,
         address to,
         bytes calldata hookData
-    ) external returns (uint256);
+    ) external returns (bytes4, uint256);
 
     function beforeFund(
         address caller,
@@ -30,7 +30,7 @@ interface IHooks {
         uint256 amount,
         uint256 instant,
         bytes calldata hookData
-    ) external returns (uint256);
+    ) external returns (bytes4, uint256);
 
     function beforeCash(
         address caller,
@@ -38,20 +38,21 @@ interface IHooks {
         address to,
         uint256 amount,
         bytes calldata hookData
-    ) external returns (uint256);
+    ) external returns (bytes4, uint256);
 
     function beforeApprove(
         address caller,
         NotaState calldata nota,
         address to
-    ) external returns (uint256);
+    ) external returns (bytes4, uint256);
 
     function beforeBurn(
         address caller,
         NotaState calldata nota
-    ) external;
+    ) external returns (bytes4);
 
     function beforeTokenURI(
-        uint256 notaId
-    ) external view returns (string memory, string memory);
+        address caller,
+        NotaState calldata nota
+    ) external view returns (bytes4, string memory, string memory);
 }

--- a/contracts/src/interfaces/INotaRegistrar.sol
+++ b/contracts/src/interfaces/INotaRegistrar.sol
@@ -15,7 +15,7 @@ interface INotaRegistrar {
         uint256 escrowed; // Slot1
         address currency; // Slot2
         /* 96 bits free */
-        IHooks hook; // Slot3
+        IHooks hooks; // Slot3
         /* 96 bits free */
     }
 

--- a/contracts/src/libraries/Hooks.sol
+++ b/contracts/src/libraries/Hooks.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.16;
+import {IHooks} from "../interfaces/IHooks.sol";
+import "forge-std/console.sol";
+
+library Hooks {
+    using Hooks for IHooks;
+
+    error HookFailure();
+    error InvalidHookResponse();
+
+    function callHook(IHooks self, bytes4 selector, bytes memory data) internal returns (uint256) {
+        (, bytes memory result) = address(self).call(abi.encodePacked(selector, data));
+        if (result.length < 36) revert HookFailure(); // 4 bytes for selector, 32 bytes for uint256
+            
+        // Extract the returned selector and fee
+        bytes4 returnedSelector;
+        uint256 hookFee;
+        assembly {
+            // Load the first 4 bytes (selector) from the result
+            returnedSelector := mload(add(result, 32))
+            // Load the next 32 bytes (uint256 fee) from the result
+            hookFee := mload(add(result, 64))
+        }
+
+        if (returnedSelector != selector) revert InvalidHookResponse();
+
+        return hookFee;
+    }
+
+    function beforeWrite(
+        IHooks self,
+        IHooks.NotaState memory nota,
+        uint256 instant,
+        bytes calldata hookData
+    ) internal returns (uint256) {
+        return callHook(self, IHooks.beforeWrite.selector, abi.encode(msg.sender, nota, instant, hookData));
+    }
+
+    function beforeTransfer(
+        IHooks self,
+        IHooks.NotaState memory nota,
+        address to,
+        bytes memory hookData
+    ) internal returns (uint256) {
+        return callHook(self, IHooks.beforeTransfer.selector, abi.encode(msg.sender, nota, to, hookData));
+    }
+
+    function beforeFund(
+        IHooks self,
+        IHooks.NotaState memory nota,
+        uint256 amount,
+        uint256 instant,
+        bytes calldata hookData
+    ) internal returns (uint256) {
+        return callHook(self, IHooks.beforeFund.selector, abi.encode(msg.sender, nota, amount, instant, hookData));
+    }
+
+    function beforeCash(
+        IHooks self,
+        IHooks.NotaState memory nota,
+        address to,
+        uint256 amount,
+        bytes calldata hookData
+    ) internal returns (uint256) {
+        return callHook(self, IHooks.beforeCash.selector, abi.encode(msg.sender, nota, to, amount, hookData));
+    }
+
+    function beforeApprove(
+        IHooks self,
+        IHooks.NotaState memory nota,
+        address to
+    ) internal returns (uint256) {
+        return callHook(self, IHooks.beforeApprove.selector, abi.encode(msg.sender, nota, to));
+    }
+
+    function beforeBurn(
+        IHooks self,
+        IHooks.NotaState memory nota
+    ) internal {
+        (, bytes memory result) = address(self).call(abi.encodePacked(IHooks.beforeBurn.selector, abi.encode(msg.sender, nota)));
+        if (result.length < 4) revert HookFailure(); // 4 bytes for selector
+
+        bytes4 returnedSelector;
+        assembly { returnedSelector := mload(add(result, 32)) }  // Extract the returned selector
+
+        if (returnedSelector != IHooks.beforeBurn.selector) revert InvalidHookResponse();
+    }
+
+    function beforeTokenURI(
+        IHooks self,
+        IHooks.NotaState memory nota
+    ) internal view returns (string memory, string memory) {
+        (bytes4 returnedSelector, string memory hookAttributes, string memory hookKeys) = self.beforeTokenURI(msg.sender, nota);
+        if (returnedSelector != IHooks.beforeTokenURI.selector) revert InvalidHookResponse();
+
+        return (hookAttributes, hookKeys);
+    }
+}

--- a/contracts/test/Registrar.t.sol
+++ b/contracts/test/Registrar.t.sol
@@ -261,7 +261,7 @@ contract RegistrarTest is Test {
         NotaRegistrar.Nota memory postNota = REGISTRAR.notaInfo(initialId);
         assertEq(postNota.currency, currency, "Incorrect token");
         assertEq(postNota.escrowed, escrowed, "Incorrect escrow");
-        assertEq(address(postNota.hook), address(hook), "Incorrect hook");
+        assertEq(address(postNota.hooks), address(hook), "Incorrect hook");
 
         assertEq(IERC20(currency).balanceOf(caller), initialCallerTokenBalance - totalAmount, "Caller currency balance didn't decrease");
         assertEq(IERC20(currency).balanceOf(owner), initialOwnerTokenBalance + instant, "Owner currency balance didn't decrease");
@@ -292,9 +292,9 @@ contract RegistrarTest is Test {
         IERC20 currency = IERC20(preNota.currency);
         uint256 initialCallerTokenBalance = currency.balanceOf(caller);
         uint256 initialOwnerTokenBalance = currency.balanceOf(notaOwner);
-        uint256 initialHookRevenue = REGISTRAR.hookRevenue(preNota.hook, address(currency));
+        uint256 initialHookRevenue = REGISTRAR.hookRevenue(preNota.hooks, address(currency));
         
-        uint256 totalAmount = _calcTotalFees(preNota.hook, amount, instant);
+        uint256 totalAmount = _calcTotalFees(preNota.hooks, amount, instant);
         uint256 hookFee = totalAmount - (amount + instant);
 
         vm.prank(caller);
@@ -303,7 +303,7 @@ contract RegistrarTest is Test {
         assertEq(preNota.escrowed, REGISTRAR.notaEscrowed(notaId) - amount, "Escrowed amount didn't increment properly");
         assertEq(currency.balanceOf(caller), initialCallerTokenBalance - totalAmount, "Caller currency balance didn't decrease");
         assertEq(currency.balanceOf(notaOwner), initialOwnerTokenBalance + instant, "Owner currency balance didn't decrease");
-        assertEq(initialHookRevenue, REGISTRAR.hookRevenue(preNota.hook, address(currency)) + hookFee, "Owner currency balance didn't decrease");
+        assertEq(initialHookRevenue, REGISTRAR.hookRevenue(preNota.hooks, address(currency)) + hookFee, "Owner currency balance didn't decrease");
     }
 
     function _registrarCashHelper(address caller, uint256 notaId, uint256 amount, address to, bytes memory hookData) internal {
@@ -312,9 +312,9 @@ contract RegistrarTest is Test {
 
         IERC20 currency = IERC20(preNota.currency);
         uint256 initialToTokenBalance = currency.balanceOf(to);
-        uint256 initialHookRevenue = REGISTRAR.hookRevenue(preNota.hook, address(currency));
+        uint256 initialHookRevenue = REGISTRAR.hookRevenue(preNota.hooks, address(currency));
         
-        uint256 totalAmount = _calcTotalFees(preNota.hook, amount, 0);
+        uint256 totalAmount = _calcTotalFees(preNota.hooks, amount, 0);
         uint256 hookFee = totalAmount - amount;
 
         vm.prank(caller);
@@ -322,7 +322,7 @@ contract RegistrarTest is Test {
 
          assertEq(preNota.escrowed, REGISTRAR.notaEscrowed(notaId) + totalAmount, "Total amount didnt decrement properly");
          assertEq(currency.balanceOf(to), initialToTokenBalance + amount, "Owner currency balance didn't increase");
-         assertEq(initialHookRevenue, REGISTRAR.hookRevenue(preNota.hook, address(currency)) + hookFee, "Owner currency balance didn't decrease");
+         assertEq(initialHookRevenue, REGISTRAR.hookRevenue(preNota.hooks, address(currency)) + hookFee, "Owner currency balance didn't decrease");
     }
 
     // function _registrarApproveHelper(address caller, address to, uint256 notaId) internal {


### PR DESCRIPTION
Add a Hooks library to perform hook call validations. This ensure that the hook contract being called implements the IHooks interface and doesn't succeed with a fallback function while keeping the NotaRegistrar's code simple to understand.