### PR TITLE
Almaraz/gov fee max

### DIFF
--- a/contracts/src/NotaRegistrar.sol
+++ b/contracts/src/NotaRegistrar.sol
@@ -57,19 +57,14 @@ contract NotaRegistrar is ERC4906, INotaRegistrar, RegistrarGov, ReentrancyGuard
 
     /// @inheritdoc INotaRegistrar
     function transferFrom(address from, address to, uint256 notaId) public nonReentrant override(ERC721, IERC721, INotaRegistrar) {
-        _transferHookTakeFee(from, to, notaId, abi.encode(""));
+        _transferHookTakeFee(to, notaId, abi.encode(""));
         _transfer(from, to, notaId);
         emit MetadataUpdate(notaId);
     }
 
     /// @inheritdoc INotaRegistrar
-    function safeTransferFrom(
-        address from,
-        address to,
-        uint256 notaId,
-        bytes memory hookData
-    ) public override(ERC721, IERC721, INotaRegistrar) nonReentrant {
-        _transferHookTakeFee(from, to, notaId, hookData);
+    function safeTransferFrom( address from, address to, uint256 notaId, bytes memory hookData) public override(ERC721, IERC721, INotaRegistrar) nonReentrant {
+        _transferHookTakeFee(to, notaId, hookData);
         _safeTransfer(from, to, notaId, abi.encode(""));
         emit MetadataUpdate(notaId);
     }
@@ -140,7 +135,7 @@ contract NotaRegistrar is ERC4906, INotaRegistrar, RegistrarGov, ReentrancyGuard
                                 Strings.toHexString(nota.currency),
                                 '"},{"trait_type":"Amount","display_type":"number","value":',
                                 Strings.toString(nota.escrowed),
-                                '},{"trait_type":"Escrow Conditions","value":"', // Wrapper vs Hook vs Conditions vs Conditions Contract
+                                '},{"trait_type":"Wrapper Contract","value":"',
                                 Strings.toHexString(address(nota.hooks)),
                                 '"}',
                                 hookAttributes,  // of form: ',{"trait_type":"<trait>","value":"<value>"}'
@@ -162,9 +157,8 @@ contract NotaRegistrar is ERC4906, INotaRegistrar, RegistrarGov, ReentrancyGuard
         emit MetadataUpdate(notaId);
     }
 
-    /*//////////////////////// HELPERS ///////////////////////////*/ // TODO move these to a library??
+    /*//////////////////////// HELPERS ///////////////////////////*/
     function _transferHookTakeFee(
-        address from,
         address to,
         uint256 notaId,
         bytes memory hookData

--- a/contracts/src/RegistrarGov.sol
+++ b/contracts/src/RegistrarGov.sol
@@ -10,11 +10,24 @@ contract RegistrarGov is Ownable, IRegistrarGov {
     using SafeERC20 for IERC20;
 
     mapping(IHooks hook => mapping(address token => uint256 revenue)) internal _hookRevenue;
+    mapping(IHooks hook => mapping(address token => uint256 totalRevenue)) internal _hookTotalRevenue;
+    mapping(address token => uint256 revenue) internal _protocolRevenue;
+    mapping(address token => uint256 totalRevenue) internal _protocolTotalRevenue;
     mapping(bytes32 hook => bool isWhitelisted) internal _codeHashWhitelist;
+    uint256 public constant MAX_PROTOCOL_FEE = 1000; // 10% in basis points
+    uint256 public protocolFee; // In basis points (1/100 of a percent)
     string internal _contractURI;
 
     event ContractURIUpdated();
-    event HookWithdraw(address indexed hook, address indexed token, uint256 amount, address indexed to);
+    event ProtocolFeeSet(uint256 newFee);
+    event HookWithdraw(address indexed hook, address indexed token, uint256 amount, address indexed to, uint256 fee);
+    event ProtocolRevenueCollected(address indexed token, uint256 amount, address indexed to);
+
+    function setProtocolFee(uint256 newFee) external onlyOwner {
+        require(newFee <= MAX_PROTOCOL_FEE, "Fee exceeds maximum");
+        protocolFee = newFee;
+        emit ProtocolFeeSet(newFee);
+    }
 
     function setContractURI(string calldata uri) external onlyOwner {
         _contractURI = uri;
@@ -67,12 +80,35 @@ contract RegistrarGov is Ownable, IRegistrarGov {
 
     function hookWithdraw(address token, uint256 amount, address to) external {
         _hookRevenue[IHooks(msg.sender)][token] -= amount;  // reverts on underflow
-        if (amount > 0) IERC20(token).safeTransfer(to, amount);
-        emit HookWithdraw(msg.sender, token, amount, to);
+        uint256 fee = (amount * protocolFee) / 10000;
+        uint256 amountAfterFee = amount - fee;
+        _protocolRevenue[token] += fee;
+        _protocolTotalRevenue[token] += fee;
+        _hookTotalRevenue[IHooks(msg.sender)][token] += amount;
+        IERC20(token).safeTransfer(to, amountAfterFee);
+        emit HookWithdraw(msg.sender, token, amount, to, fee);
+    }
+
+    function collectProtocolRevenue(address token, uint256 amount, address to) external onlyOwner {
+        require(amount <= _protocolRevenue[token], "Insufficient protocol revenue");
+        _protocolRevenue[token] -= amount;
+        IERC20(token).safeTransfer(to, amount);
+        emit ProtocolRevenueCollected(token, amount, to);
     }
 
     function hookRevenue(IHooks hook, address currency) external view returns(uint256) {
         return _hookRevenue[hook][currency];
     }
 
+    function hookTotalRevenue(IHooks hook, address currency) external view returns(uint256) {
+        return _hookTotalRevenue[hook][currency];
+    }
+
+    function protocolRevenue(address currency) external view returns(uint256) {
+        return _protocolRevenue[currency];
+    }
+
+    function protocolTotalRevenue(address currency) external view returns(uint256) {
+        return _protocolTotalRevenue[currency];
+    }
 }

--- a/contracts/src/RegistrarGov.sol
+++ b/contracts/src/RegistrarGov.sol
@@ -80,15 +80,14 @@ abstract contract RegistrarGov is Ownable, IRegistrarGov {
     function hookWithdraw(address token, uint256 amount, address to) external {
         _hookRevenue[IHooks(msg.sender)][token] -= amount;  // reverts on underflow
         uint256 fee = (amount * _protocolFee) / 10000;
-        uint256 amountAfterFee = amount - fee;
         _protocolRevenue[token] += fee;
         _protocolTotalRevenue[token] += fee;
         _hookTotalRevenue[IHooks(msg.sender)][token] += amount;
-        IERC20(token).safeTransfer(to, amountAfterFee);
+        IERC20(token).safeTransfer(to, amount - fee);
         emit HookRevenueCollected(msg.sender, token, amount, to, fee);
     }
 
-    function collectProtocolRevenue(address token, uint256 amount, address to) external onlyOwner {
+    function protocolWithdraw(address token, uint256 amount, address to) external onlyOwner {
         require(amount <= _protocolRevenue[token], "Insufficient protocol revenue");
         _protocolRevenue[token] -= amount;
         IERC20(token).safeTransfer(to, amount);

--- a/contracts/src/interfaces/IRegistrarGov.sol
+++ b/contracts/src/interfaces/IRegistrarGov.sol
@@ -31,7 +31,7 @@ interface IRegistrarGov {
 
     function protocolFee() external returns(uint256);
 
-    function collectProtocolRevenue(address token, uint256 amount, address to) external;
+    function protocolWithdraw(address token, uint256 amount, address to) external;
 
     function hookTotalRevenue(IHooks hook, address currency) external view returns(uint256);
 

--- a/contracts/src/interfaces/IRegistrarGov.sol
+++ b/contracts/src/interfaces/IRegistrarGov.sol
@@ -4,9 +4,14 @@ import {IHooks} from "./IHooks.sol";
 
 interface IRegistrarGov {
 
+    event ContractURIUpdated();
     event HookWhitelisted(address indexed user, IHooks indexed hook, bool isAccepted);
-
     event TokenWhitelisted(address caller, address indexed token, bool indexed isAccepted);
+    event ProtocolFeeSet(uint256 newFee);
+    event ProtocolRevenueCollected(address indexed token, uint256 amount, address indexed to);
+    event HookRevenueCollected(address indexed hook, address indexed token, uint256 amount, address indexed to, uint256 fee);
+    
+    function contractURI() external view returns (string memory);
 
     function setContractURI(string calldata uri) external;
     
@@ -21,4 +26,18 @@ interface IRegistrarGov {
     function hookWithdraw(address token, uint256 amount, address payoutAccount) external;
 
     function hookRevenue(IHooks hook, address currency) external view returns(uint256);
+
+    function setProtocolFee(uint256 newFee) external;
+
+    function protocolFee() external returns(uint256);
+
+    function collectProtocolRevenue(address token, uint256 amount, address to) external;
+
+    function hookTotalRevenue(IHooks hook, address currency) external view returns(uint256);
+
+    function protocolRevenue(address currency) external view returns(uint256);
+
+    function protocolTotalRevenue(address currency) external view returns(uint256);
+
+    function validWrite(IHooks hook, address token) external view returns (bool);
 }


### PR DESCRIPTION
- Add a protocol fee with a max fee of 10% on hook revenue
- Add total revenue tracking for both hooks and the protocol (enables using these for Notas)
- Change RegistrarGov to be an abstract contract since it is intended to be inherited by NotaRegistrar
- Add protocol fee unit tests