### PR TITLE
Nota Hook property rename

### DIFF
--- a/contracts/src/NotaRegistrar.sol
+++ b/contracts/src/NotaRegistrar.sol
@@ -189,7 +189,7 @@ contract NotaRegistrar is ERC4906, INotaRegistrar, RegistrarGov, ReentrancyGuard
         return _notas[notaId].currency;
     }
 
-    function notaHook(uint256 notaId) public view exists(notaId) returns (IHooks) {
+    function notaHooks(uint256 notaId) public view exists(notaId) returns (IHooks) {
         return _notas[notaId].hooks;
     }
 }

--- a/contracts/src/interfaces/INotaRegistrar.sol
+++ b/contracts/src/interfaces/INotaRegistrar.sol
@@ -140,5 +140,5 @@ interface INotaRegistrar {
 
     function notaEscrowed(uint256 notaId) external view returns (uint256);
 
-    function notaHook(uint256 notaId) external view returns (IHooks);
+    function notaHooks(uint256 notaId) external view returns (IHooks);
 }

--- a/contracts/test/BaseRegistrarTest.t.sol
+++ b/contracts/test/BaseRegistrarTest.t.sol
@@ -151,7 +151,7 @@ abstract contract BaseRegistrarTest is Test {
 
         assertEq(REGISTRAR.notaCurrency(notaId), currency, "Incorrect currency");
         assertEq(REGISTRAR.notaEscrowed(notaId), escrowed, "Incorrect escrowed amount");
-        assertEq(address(REGISTRAR.notaHook(notaId)), address(hook), "Incorrect hook");
+        assertEq(address(REGISTRAR.notaHooks(notaId)), address(hook), "Incorrect hook");
 
         assertEq(IERC20(currency).balanceOf(caller), initialCallerTokenBalance - totalAmount, "Caller currency balance didn't decrease correctly");
         assertEq(IERC20(currency).balanceOf(owner), initialOwnerTokenBalance + instant, "Owner currency balance didn't increase correctly");


### PR DESCRIPTION
Use the "hooks" nomenclature to refer to the smart contract assigned to each nota which contains all the callable hook functions