### PR TITLE
Almaraz/update function

### DIFF
--- a/src/interfaces/IHooks.sol
+++ b/src/interfaces/IHooks.sol
@@ -34,6 +34,8 @@ interface IHooks {
 
     function beforeBurn(address caller, NotaState calldata nota) external returns (bytes4);
 
+    function beforeUpdate(address caller, NotaState calldata nota, bytes calldata hookData) external returns (bytes4, uint256);
+
     function beforeTokenURI(address caller, NotaState calldata nota)
         external
         view

--- a/src/interfaces/INotaRegistrar.sol
+++ b/src/interfaces/INotaRegistrar.sol
@@ -97,10 +97,10 @@ interface INotaRegistrar {
     function burn(uint256 notaId) external;
 
     /**
-     * @notice Updates the metadata of a Nota
-     * @dev Caller must be the Nota's hook
+     * @notice Updates the state of a Nota within it's hook
+     * @dev No requirements except what the hook enforces
      */
-    function metadataUpdate(uint256 notaId) external;
+    function update(uint256 notaId, bytes calldata hookData) external;
 
     function notaInfo(uint256 notaId) external view returns (Nota memory);
 

--- a/src/libraries/Hooks.sol
+++ b/src/libraries/Hooks.sol
@@ -76,6 +76,13 @@ library Hooks {
         if (returnedSelector != IHooks.beforeBurn.selector) revert InvalidHookResponse();
     }
 
+    function beforeUpdate(IHooks self, IHooks.NotaState memory nota, bytes calldata hookData)
+        internal
+        returns (uint256)
+    {
+        return callHook(self, IHooks.beforeUpdate.selector, abi.encode(msg.sender, nota, hookData));
+    }
+
     function beforeTokenURI(IHooks self, IHooks.NotaState memory nota)
         internal
         view

--- a/test/mock/MockHook.sol
+++ b/test/mock/MockHook.sol
@@ -54,6 +54,10 @@ contract MockHook is IHooks {
         return IHooks.beforeBurn.selector;
     }
 
+    function beforeUpdate(address, IHooks.NotaState memory, bytes calldata) external view returns (bytes4, uint256) {
+        return (IHooks.beforeApprove.selector, fee);
+    }
+
     function beforeTokenURI(address, IHooks.NotaState memory)
         external
         pure

--- a/test/mock/MockHook.sol
+++ b/test/mock/MockHook.sol
@@ -55,7 +55,7 @@ contract MockHook is IHooks {
     }
 
     function beforeUpdate(address, IHooks.NotaState memory, bytes calldata) external view returns (bytes4, uint256) {
-        return (IHooks.beforeApprove.selector, fee);
+        return (IHooks.beforeUpdate.selector, fee);
     }
 
     function beforeTokenURI(address, IHooks.NotaState memory)


### PR DESCRIPTION
Adds a registrar `update` function with corresponding hook

Circumvents (at least some) cases where users would need to call the hook directly to change the hook-stored state of their nota

This allows:
- Arbitrary hook function calls 
- Ability to take a fee on nota updates that don't directly affect ownership or escrow and
- Updates to the hook's state will trigger a metadata update event