### PR TITLE
Add notaData view function

### DIFF
--- a/src/NotaRegistrar.sol
+++ b/src/NotaRegistrar.sol
@@ -247,4 +247,19 @@ contract NotaRegistrar is ERC4906, INotaRegistrar, RegistrarGov, ReentrancyGuard
     function notaHooks(uint256 notaId) public view exists(notaId) returns (IHooks) {
         return _notas[notaId].hooks;
     }
+
+    function notaData(uint256 notaId) public view exists(notaId) returns (Nota memory, bytes memory) {
+        Nota memory nota = _notas[notaId];
+        bytes memory data = nota.hooks.notaBytes(notaId);
+        return (nota, data);
+    }
+
+    function notaStateData(uint256 notaId) public view exists(notaId) returns (IHooks.NotaState memory, bytes memory) {
+        Nota memory nota = _notas[notaId];
+        bytes memory data = nota.hooks.notaBytes(notaId);
+        return (
+                IHooks.NotaState(notaId, nota.currency, nota.escrowed, ownerOf(notaId), getApproved(notaId)),
+                data
+            );
+    }
 }

--- a/src/interfaces/IHooks.sol
+++ b/src/interfaces/IHooks.sol
@@ -40,4 +40,6 @@ interface IHooks {
         external
         view
         returns (bytes4, string memory, string memory);
+
+    function notaBytes(uint256 notaId) external view returns (bytes memory);
 }

--- a/test/mock/MockHook.sol
+++ b/test/mock/MockHook.sol
@@ -65,4 +65,8 @@ contract MockHook is IHooks {
     {
         return (IHooks.beforeTokenURI.selector, "", "");
     }
+
+    function notaBytes(uint256) external pure override returns (bytes memory) {
+        return "";
+    }
 }


### PR DESCRIPTION
Allows on and offchain queries of full (including hook specific) nota state through a standard interface on the NotaRegistrar