### PR TITLE
Test Suites for Registrar Actions

### DIFF
--- a/test/Approve.t.sol
+++ b/test/Approve.t.sol
@@ -4,7 +4,46 @@ pragma solidity ^0.8.16;
 import "./BaseRegistrarTest.t.sol";
 
 contract ApproveTest is BaseRegistrarTest {
+    address public caller = address(0xbeef);
+    address public owner = address(0xdead);
+    address public spender = address(0xcafe);
+    uint256 public notaId;
+
     function setUp() public override {
         super.setUp();
+        
+        _fundCallerApproveAddress(caller, DAI, 100, address(REGISTRAR));
+        notaId = _registrarWriteHelper(caller, address(DAI), 100, 0, owner, HOOK, "");
+    }
+
+    function testApprove() public {
+        vm.prank(owner);
+        _registrarApproveHelper(owner, spender, notaId);
+    }
+
+    function testApproveUnauthorized(address unauthorized) public {
+        vm.assume(unauthorized != owner);
+        vm.assume(unauthorized != address(0));
+        
+        vm.expectRevert("ERC721: approve caller is not token owner or approved for all");
+        vm.prank(unauthorized);
+        REGISTRAR.approve(spender, notaId);
+    }
+
+    function testApproveAll() public {
+        vm.expectEmit(true, true, true, true);
+        emit IERC721.ApprovalForAll(owner, spender, true);
+
+        vm.prank(owner);
+        REGISTRAR.setApprovalForAll(spender, true);
+        
+        assertTrue(REGISTRAR.isApprovedForAll(owner, spender));
+    }
+
+    function testApproveNonexistentToken(uint256 invalidNotaId) public {
+        vm.assume(invalidNotaId >= REGISTRAR.nextId());
+        
+        vm.expectRevert(INotaRegistrar.NonExistent.selector);
+        REGISTRAR.approve(spender, invalidNotaId);
     }
 }

--- a/test/BaseRegistrarTest.t.sol
+++ b/test/BaseRegistrarTest.t.sol
@@ -17,7 +17,6 @@ abstract contract BaseRegistrarTest is Test {
     NotaRegistrar public REGISTRAR;
     MockHook public HOOK;
     MockERC20 public DAI;
-    uint256 public immutable TOKEN_SUPPLY = 1_000_000_000_000e18;
 
     function setUp() public virtual {
         REGISTRAR = new NotaRegistrar(address(this));
@@ -59,11 +58,16 @@ abstract contract BaseRegistrarTest is Test {
         uint256 initialAllowance = token.allowance(caller, toApprove);
 
         token.mint(caller, total);
-        assertEq(token.balanceOf(caller), initialBalance + total, "Token Transfer Failed");
+        assertEq(token.balanceOf(caller), initialBalance + total, "Token Mint Failed");
 
         vm.prank(caller);
         token.approve(toApprove, total);
-        assertEq(token.allowance(caller, toApprove), initialAllowance + total, "Approval Failed");
+
+        if (initialAllowance == total) {
+            assertEq(token.allowance(caller, toApprove), total, "Approval Failed");
+        } else {
+            assertNotEq(token.allowance(caller, toApprove), initialAllowance, "Approval Failed");
+        }
     }
 
     function _URIFormat(string memory _string) internal pure returns (string memory) {
@@ -71,12 +75,9 @@ abstract contract BaseRegistrarTest is Test {
     }
 
     function _registrarWriteAssumptions(address caller, uint256 escrow, uint256 instant, address owner) internal view {
-        vm.assume(caller != address(0) && caller != owner && owner != address(0));   // TODO not sure if caller != owner is necessary
-        vm.assume(  // TODO could just change to check if owner is a contract
-            owner != address(REGISTRAR) && caller != address(REGISTRAR) && caller != address(this)
-                && owner != address(this)
-        );
-        vm.assume(((escrow >> 2) + (instant >> 2)) <= (TOKEN_SUPPLY >> 2));
+        vm.assume(((escrow >> 2) + (instant >> 2)) < (type(uint256).max >> 2));
+        vm.assume(caller != address(0) && owner != address(0) && caller != owner);   // TODO not sure if caller != owner is necessary
+        vm.assume(!_isContract(owner) && !_isContract(caller));
     }
 
     function _registrarTransferAssumptions(address caller, address from, address to, uint256 notaId) internal view {
@@ -187,14 +188,11 @@ abstract contract BaseRegistrarTest is Test {
         uint256 hookFee; // TODO
 
         vm.expectEmit(true, true, true, true);
-        emit IERC721.Transfer(from, to, notaId);
-
+        emit INotaRegistrar.Transferred(caller, notaId, hookFee, abi.encode(""));
         vm.expectEmit(true, true, true, true);
-        emit INotaRegistrar.Transferred(caller, notaId, hookFee, "");
-
+        emit IERC721.Transfer(from, to, notaId);
         vm.expectEmit(true, true, true, true);
         emit IERC4906.MetadataUpdate(notaId);
-
         vm.prank(caller);
         REGISTRAR.transferFrom(from, to, notaId);
 
@@ -211,6 +209,84 @@ abstract contract BaseRegistrarTest is Test {
             initialHookRevenue,
             REGISTRAR.hookRevenue(preNota.hooks, address(preNota.currency)) + hookFee,
             "Owner currency balance didn't decrease"
+        );
+    }
+
+    function _registrarSafeTransferHelper(address caller, address from, address to, uint256 notaId) internal {
+        uint256 initialId = REGISTRAR.nextId();
+        uint256 initialFromBalance = REGISTRAR.balanceOf(from);
+        uint256 initialToBalance = REGISTRAR.balanceOf(to);
+        assertEq(REGISTRAR.ownerOf(notaId), from, "From address should be the current owner");
+        NotaRegistrar.Nota memory preNota = REGISTRAR.notaInfo(notaId);
+
+        uint256 initialHookRevenue = REGISTRAR.hookRevenue(preNota.hooks, address(preNota.currency));
+        uint256 hookFee;
+
+        vm.expectEmit(true, true, true, true);
+        emit INotaRegistrar.Transferred(caller, notaId, hookFee, abi.encode(""));
+        vm.expectEmit(true, true, true, true);
+        emit IERC721.Transfer(from, to, notaId);
+        vm.expectEmit(true, true, true, true);
+        emit IERC4906.MetadataUpdate(notaId);
+
+        vm.prank(caller);
+        REGISTRAR.safeTransferFrom(from, to, notaId);
+
+        assertEq(REGISTRAR.nextId(), initialId, "NextId should remain unchanged");
+        assertEq(REGISTRAR.balanceOf(from), initialFromBalance - 1, "Sender's balance should decrease by 1");
+        assertEq(REGISTRAR.balanceOf(to), initialToBalance + 1, "Recipient's balance should increase by 1");
+        assertEq(REGISTRAR.ownerOf(notaId), to, "Recipient should be the new owner of the token");
+
+        NotaRegistrar.Nota memory postNota = REGISTRAR.notaInfo(notaId);
+        assertEq(postNota.escrowed, preNota.escrowed, "Escrowed amount should not change");
+        assertEq(postNota.currency, preNota.currency, "Currency should not change");
+        assertEq(address(postNota.hooks), address(preNota.hooks), "Hook should not change");
+        assertEq(
+            initialHookRevenue,
+            REGISTRAR.hookRevenue(preNota.hooks, address(preNota.currency)) + hookFee,
+            "Hook revenue should be updated correctly"
+        );
+    }
+
+    function _registrarSafeTransferWithDataHelper(
+        address caller, 
+        address from, 
+        address to, 
+        uint256 notaId, 
+        bytes memory data
+    ) internal {
+        uint256 initialId = REGISTRAR.nextId();
+        uint256 initialFromBalance = REGISTRAR.balanceOf(from);
+        uint256 initialToBalance = REGISTRAR.balanceOf(to);
+        assertEq(REGISTRAR.ownerOf(notaId), from, "From address should be the current owner");
+        NotaRegistrar.Nota memory preNota = REGISTRAR.notaInfo(notaId);
+
+        uint256 initialHookRevenue = REGISTRAR.hookRevenue(preNota.hooks, address(preNota.currency));
+        uint256 hookFee;
+
+        vm.expectEmit(true, true, true, true);
+        emit INotaRegistrar.Transferred(caller, notaId, hookFee, data);
+        vm.expectEmit(true, true, true, true);
+        emit IERC721.Transfer(from, to, notaId);
+        vm.expectEmit(true, true, true, true);
+        emit IERC4906.MetadataUpdate(notaId);
+
+        vm.prank(caller);
+        REGISTRAR.safeTransferFrom(from, to, notaId, data);
+
+        assertEq(REGISTRAR.nextId(), initialId, "NextId should remain unchanged");
+        assertEq(REGISTRAR.balanceOf(from), initialFromBalance - 1, "Sender's balance should decrease by 1");
+        assertEq(REGISTRAR.balanceOf(to), initialToBalance + 1, "Recipient's balance should increase by 1");
+        assertEq(REGISTRAR.ownerOf(notaId), to, "Recipient should be the new owner of the token");
+
+        NotaRegistrar.Nota memory postNota = REGISTRAR.notaInfo(notaId);
+        assertEq(postNota.escrowed, preNota.escrowed, "Escrowed amount should not change");
+        assertEq(postNota.currency, preNota.currency, "Currency should not change");
+        assertEq(address(postNota.hooks), address(preNota.hooks), "Hook should not change");
+        assertEq(
+            initialHookRevenue,
+            REGISTRAR.hookRevenue(preNota.hooks, address(preNota.currency)) + hookFee,
+            "Hook revenue should be updated correctly"
         );
     }
 
@@ -308,17 +384,15 @@ abstract contract BaseRegistrarTest is Test {
     function _registrarBurnHelper(address caller, uint256 notaId) internal {
         NotaRegistrar.Nota memory preNota = REGISTRAR.notaInfo(notaId);
         address owner = REGISTRAR.ownerOf(notaId);
-        address approved = REGISTRAR.getApproved(notaId);
-        vm.assume(caller == owner || caller == approved);
 
         uint256 initialId = REGISTRAR.nextId();
         uint256 ownerBalance = REGISTRAR.balanceOf(owner);
 
-        // vm.expectEmit(true, true, true, true);
-        // emit INotaRegistrar.Burned(caller, notaId);
-
         vm.expectEmit(true, true, true, true);
         emit IERC721.Transfer(owner, address(0), notaId);
+
+        vm.expectEmit(true, true, true, true);
+        emit INotaRegistrar.Burned(caller, notaId); // , abi.encode("")
 
         vm.prank(caller);
         REGISTRAR.burn(notaId);
@@ -339,6 +413,30 @@ abstract contract BaseRegistrarTest is Test {
             REGISTRAR.hookRevenue(preNota.hooks, preNota.currency),
             preNota.escrowed,
             "Hook revenue should include burned escrowed amount"
+        );
+    }
+
+    function _registrarUpdateHelper(address caller, uint256 notaId, bytes memory hookData) internal {
+        NotaRegistrar.Nota memory preNota = REGISTRAR.notaInfo(notaId);
+        address owner = REGISTRAR.ownerOf(notaId);
+
+        uint256 initialHookRevenue = REGISTRAR.hookRevenue(preNota.hooks, address(preNota.currency));
+        uint256 hookFee; // = totalAmount - amount;  // TODO
+
+        // vm.expectEmit(true, true, true, true);  // TODO
+        // emit INotaRegistrar.Updated(caller, notaId, hookData);
+
+        vm.expectEmit(true, true, true, true);
+        emit IERC4906.MetadataUpdate(notaId);
+
+        vm.prank(caller);
+        REGISTRAR.update(notaId, hookData);
+
+        assertEq(REGISTRAR.ownerOf(notaId), owner, "Owner should remain the same");
+        assertEq(
+            REGISTRAR.hookRevenue(preNota.hooks, address(preNota.currency)),
+            initialHookRevenue + hookFee,
+            "Hook revenue didn't increase correctly"
         );
     }
 }

--- a/test/BaseRegistrarTest.t.sol
+++ b/test/BaseRegistrarTest.t.sol
@@ -212,43 +212,7 @@ abstract contract BaseRegistrarTest is Test {
         );
     }
 
-    function _registrarSafeTransferHelper(address caller, address from, address to, uint256 notaId) internal {
-        uint256 initialId = REGISTRAR.nextId();
-        uint256 initialFromBalance = REGISTRAR.balanceOf(from);
-        uint256 initialToBalance = REGISTRAR.balanceOf(to);
-        assertEq(REGISTRAR.ownerOf(notaId), from, "From address should be the current owner");
-        NotaRegistrar.Nota memory preNota = REGISTRAR.notaInfo(notaId);
-
-        uint256 initialHookRevenue = REGISTRAR.hookRevenue(preNota.hooks, address(preNota.currency));
-        uint256 hookFee;
-
-        vm.expectEmit(true, true, true, true);
-        emit INotaRegistrar.Transferred(caller, notaId, hookFee, abi.encode(""));
-        vm.expectEmit(true, true, true, true);
-        emit IERC721.Transfer(from, to, notaId);
-        vm.expectEmit(true, true, true, true);
-        emit IERC4906.MetadataUpdate(notaId);
-
-        vm.prank(caller);
-        REGISTRAR.safeTransferFrom(from, to, notaId);
-
-        assertEq(REGISTRAR.nextId(), initialId, "NextId should remain unchanged");
-        assertEq(REGISTRAR.balanceOf(from), initialFromBalance - 1, "Sender's balance should decrease by 1");
-        assertEq(REGISTRAR.balanceOf(to), initialToBalance + 1, "Recipient's balance should increase by 1");
-        assertEq(REGISTRAR.ownerOf(notaId), to, "Recipient should be the new owner of the token");
-
-        NotaRegistrar.Nota memory postNota = REGISTRAR.notaInfo(notaId);
-        assertEq(postNota.escrowed, preNota.escrowed, "Escrowed amount should not change");
-        assertEq(postNota.currency, preNota.currency, "Currency should not change");
-        assertEq(address(postNota.hooks), address(preNota.hooks), "Hook should not change");
-        assertEq(
-            initialHookRevenue,
-            REGISTRAR.hookRevenue(preNota.hooks, address(preNota.currency)) + hookFee,
-            "Hook revenue should be updated correctly"
-        );
-    }
-
-    function _registrarSafeTransferWithDataHelper(
+    function _registrarSafeTransferHelper(
         address caller, 
         address from, 
         address to, 
@@ -273,7 +237,6 @@ abstract contract BaseRegistrarTest is Test {
 
         vm.prank(caller);
         REGISTRAR.safeTransferFrom(from, to, notaId, data);
-
         assertEq(REGISTRAR.nextId(), initialId, "NextId should remain unchanged");
         assertEq(REGISTRAR.balanceOf(from), initialFromBalance - 1, "Sender's balance should decrease by 1");
         assertEq(REGISTRAR.balanceOf(to), initialToBalance + 1, "Recipient's balance should increase by 1");

--- a/test/Burn.t.sol
+++ b/test/Burn.t.sol
@@ -4,7 +4,42 @@ pragma solidity ^0.8.16;
 import "./BaseRegistrarTest.t.sol";
 
 contract BurnTest is BaseRegistrarTest {
+    address public caller = address(0xbeef);
+    address public owner = address(0xdead);
+    uint256 public notaId;
+
     function setUp() public override {
         super.setUp();
+        
+        _fundCallerApproveAddress(caller, DAI, 100, address(REGISTRAR));
+        notaId = _registrarWriteHelper(caller, address(DAI), 100, 0, owner, HOOK, "");
+    }
+
+    function testBurn() public {
+        _registrarBurnHelper(owner, notaId);
+    }
+
+    function testBurnByApproved() public {
+        address approved = address(0x1234);
+
+        _registrarApproveHelper(owner, approved, notaId);
+        _registrarBurnHelper(approved, notaId);
+    }
+
+    function testBurnByOperator() public {
+        address operator = address(0x5678);
+        
+        vm.prank(owner);
+        REGISTRAR.setApprovalForAll(operator, true);
+        
+        _registrarBurnHelper(operator, notaId);
+    }
+
+    function testBurnNotOwnerOrApproved() public {
+        address notApproved = address(0x1234);
+
+        vm.expectRevert("NOT_APPROVED_OR_OWNER");
+        vm.prank(notApproved);
+        REGISTRAR.burn(notaId);
     }
 }

--- a/test/Cash.t.sol
+++ b/test/Cash.t.sol
@@ -4,7 +4,60 @@ pragma solidity ^0.8.16;
 import "./BaseRegistrarTest.t.sol";
 
 contract CashTest is BaseRegistrarTest {
+    address public caller = address(0xbeef);
+    address public owner = address(0xdead);
+    address public to = address(0xcafe);
+    uint256 public notaId;
+
     function setUp() public override {
         super.setUp();
+        
+        _fundCallerApproveAddress(caller, DAI, 100 ether, address(REGISTRAR));
+        notaId = _registrarWriteHelper(caller, address(DAI), 1 ether, 0, owner, HOOK, "");
+    }
+
+    function testCash() public {
+        uint256 amount = 1 ether;
+        
+        _fundCallerApproveAddress(caller, DAI, amount, address(REGISTRAR));
+        _registrarFundHelper(caller, notaId, amount, 0, "");
+        
+        uint256 initialBalance = DAI.balanceOf(to);
+        REGISTRAR.cash(notaId, amount, to, "");
+        uint256 finalBalance = DAI.balanceOf(to);
+        
+        assertEq(finalBalance, initialBalance + amount, "Caller should receive the cashed out amount");
+    }
+
+    function testFuzzCash(uint256 amount) public {
+        // Bound amount to reasonable values
+        amount = bound(amount, 0.0001 ether, 99 ether);
+        
+        _fundCallerApproveAddress(caller, DAI, amount, address(REGISTRAR));
+        _registrarFundHelper(caller, notaId, amount, 0, "");
+        
+        uint256 initialBalance = DAI.balanceOf(to);
+        REGISTRAR.cash(notaId, amount, to, "");
+        uint256 finalBalance = DAI.balanceOf(to);
+        
+        assertEq(finalBalance, initialBalance + amount, "Cashed amount not received correctly");
+    }
+
+
+    function testFailCashByNonOwner() public {
+        uint256 amount = 1 ether;
+        address nonOwner = address(0xbeef);
+        
+        vm.prank(nonOwner);
+        vm.expectRevert("Ownable: caller is not the owner");
+        REGISTRAR.cash(notaId, amount, to, "");
+    }
+
+    function testCashInvalidNota() public {
+        uint256 amount = 1 ether;
+        uint256 invalidNotaId = 999;
+        
+        vm.expectRevert(INotaRegistrar.NonExistent.selector);
+        REGISTRAR.cash(invalidNotaId, amount, to, "");
     }
 }

--- a/test/Fund.t.sol
+++ b/test/Fund.t.sol
@@ -4,7 +4,46 @@ pragma solidity ^0.8.16;
 import "./BaseRegistrarTest.t.sol";
 
 contract FundTest is BaseRegistrarTest {
+    address public caller = address(0xbeef);
+    address public owner = address(0xdead);
+    uint256 escrowAmount = 1 ether;
+    uint256 public notaId;
+
     function setUp() public override {
         super.setUp();
+        
+        _fundCallerApproveAddress(caller, DAI, escrowAmount, address(REGISTRAR));
+        notaId = _registrarWriteHelper(caller, address(DAI), escrowAmount, 0, owner, HOOK, "");
+    }
+
+    function testFund(uint256 amount, uint256 instant) public {
+        vm.assume(((amount >> 2) + (instant >> 2)) <= (type(uint256).max >> 2) - escrowAmount);
+
+        _fundCallerApproveAddress(caller, DAI, amount + instant, address(REGISTRAR));
+        _registrarFundHelper(caller, notaId, amount, instant, "");
+    }
+
+
+    function testFundWithHookFee() public {
+        uint256 hookFee = 100;
+        HOOK.setFee(hookFee);
+        
+        _fundCallerApproveAddress(caller, DAI, 1 ether + hookFee, address(REGISTRAR));
+        _registrarFundHelper(caller, notaId, 1 ether, 0, "");
+    }
+
+    function testFundInvalidNota() public {
+        uint256 invalidNotaId = 999;
+
+        vm.expectRevert(INotaRegistrar.NonExistent.selector);
+        REGISTRAR.fund(invalidNotaId, 1 ether, 0, "");
+    }
+
+    function testFailFundWithInsufficientBalance() public {
+        uint256 amount = 100 ether;
+        uint256 instant = 50 ether;
+        
+        vm.expectRevert("ERC20: transfer amount exceeds balance");
+        _registrarFundHelper(caller, notaId, amount, instant, "");
     }
 }

--- a/test/HookFees.t.sol
+++ b/test/HookFees.t.sol
@@ -4,7 +4,30 @@ pragma solidity ^0.8.16;
 import "./BaseRegistrarTest.t.sol";
 
 contract HookFeesTest is BaseRegistrarTest {
+    address public caller = address(0xbeef);
+    address public owner = address(0xdead);
+    uint256 public notaId;
+
     function setUp() public override {
         super.setUp();
+        
+        _fundCallerApproveAddress(caller, DAI, 100 ether, address(REGISTRAR));
+        notaId = _registrarWriteHelper(caller, address(DAI), 1 ether, 0, owner, HOOK, "");
+    }
+
+    function testSetHookFee() public {
+        uint256 newFee = 100;
+        
+        HOOK.setFee(newFee);
+        assertEq(HOOK.fee(), newFee, "Hook fee should be updated");
+    }
+
+    function testFailSetHookFeeByNonOwner() public {
+        uint256 newFee = 100;
+        address nonOwner = address(0xbeef);
+        
+        vm.prank(nonOwner);
+        vm.expectRevert("Ownable: caller is not the owner");
+        HOOK.setFee(newFee);
     }
 }

--- a/test/ProtocolFees.t.sol
+++ b/test/ProtocolFees.t.sol
@@ -7,4 +7,20 @@ contract ProtocolFeesTest is BaseRegistrarTest {
     function setUp() public override {
         super.setUp();
     }
+
+    function testSetProtocolFee() public {
+        uint256 newFee = 100;
+        
+        REGISTRAR.setProtocolFee(newFee);
+        assertEq(REGISTRAR.protocolFee(), newFee, "Protocol fee should be updated");
+    }
+
+    function testSetProtocolFeeByNonOwner() public {
+        uint256 newFee = 100;
+        address nonOwner = address(0xbeef);
+        
+        vm.prank(nonOwner);
+        vm.expectRevert("Ownable: caller is not the owner");
+        REGISTRAR.setProtocolFee(newFee);
+    }
 }

--- a/test/SafeTransfer.t.sol
+++ b/test/SafeTransfer.t.sol
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.16;
+
+import "./BaseRegistrarTest.t.sol";
+
+contract SafeTransferTest is BaseRegistrarTest {
+    address public caller = address(0xbeef);
+    address public owner = address(0xdead);
+    address public recipient = address(0xcafe);
+    uint256 public notaId;
+
+    function setUp() public override {
+        super.setUp();
+        
+        _fundCallerApproveAddress(caller, DAI, 100 ether, address(REGISTRAR));
+        notaId = _registrarWriteHelper(caller, address(DAI), 1 ether, 0, owner, HOOK, "");
+    }
+
+    function testSafeTransfer() public {
+        _registrarTransferAssumptions(owner, owner, recipient, notaId);
+        _registrarSafeTransferHelper(owner, owner, recipient, notaId);
+    }
+
+    function testSafeTransferWithData() public {
+        bytes memory data = "test data";
+        _registrarTransferAssumptions(owner, owner, recipient, notaId);
+        _registrarSafeTransferWithDataHelper(owner, owner, recipient, notaId, data);
+    }
+
+    function testSafeTransferApproved() public {
+        _registrarApproveHelper(owner, caller, notaId);
+        _registrarSafeTransferHelper(caller, owner, recipient, notaId);
+    }
+
+    function testSafeTransferOperator() public {
+        vm.expectEmit(true, true, true, true);
+        emit IERC721.ApprovalForAll(owner, caller, true);
+        
+        vm.prank(owner);
+        REGISTRAR.setApprovalForAll(caller, true);
+        _registrarSafeTransferHelper(caller, owner, recipient, notaId);
+    }
+
+    function testSafeTransferFailUnauthorized(address unauthorized) public {
+        vm.assume(unauthorized != owner);
+        vm.assume(unauthorized != REGISTRAR.getApproved(notaId));
+        vm.assume(!REGISTRAR.isApprovedForAll(owner, unauthorized));
+
+        vm.expectRevert("NOT_APPROVED_OR_OWNER");
+        vm.prank(unauthorized);
+        REGISTRAR.safeTransferFrom(owner, recipient, notaId);
+    }
+
+    function testSafeTransferFailToContract() public {
+        MockERC20 contractAddr = new MockERC20("TEST", "TEST");
+        
+        vm.expectRevert("ERC721: transfer to non ERC721Receiver implementer");
+        vm.prank(owner);
+        REGISTRAR.safeTransferFrom(owner, address(contractAddr), notaId);
+    }
+
+    function testFuzzSafeTransfer(address to) public {
+        vm.assume(to != address(0));
+        vm.assume(!_isContract(to));
+        _registrarTransferAssumptions(owner, owner, to, notaId);
+        _registrarSafeTransferHelper(owner, owner, to, notaId);
+    }
+
+    function testFuzzSafeTransferWithData(address to, bytes calldata testData) public {
+        bytes memory data;
+        if (testData.length == 0){
+            data = abi.encode("");
+        } else {
+            data = testData;
+        }
+
+        vm.assume(to != address(0));
+        vm.assume(!_isContract(to));
+        _registrarTransferAssumptions(owner, owner, to, notaId);
+        _registrarSafeTransferWithDataHelper(owner, owner, to, notaId, data);
+    }
+}

--- a/test/SafeTransfer.t.sol
+++ b/test/SafeTransfer.t.sol
@@ -18,18 +18,18 @@ contract SafeTransferTest is BaseRegistrarTest {
 
     function testSafeTransfer() public {
         _registrarTransferAssumptions(owner, owner, recipient, notaId);
-        _registrarSafeTransferHelper(owner, owner, recipient, notaId);
+        _registrarSafeTransferHelper(owner, owner, recipient, notaId, abi.encode(""));
     }
 
     function testSafeTransferWithData() public {
         bytes memory data = "test data";
         _registrarTransferAssumptions(owner, owner, recipient, notaId);
-        _registrarSafeTransferWithDataHelper(owner, owner, recipient, notaId, data);
+        _registrarSafeTransferHelper(owner, owner, recipient, notaId, data);
     }
 
     function testSafeTransferApproved() public {
         _registrarApproveHelper(owner, caller, notaId);
-        _registrarSafeTransferHelper(caller, owner, recipient, notaId);
+        _registrarSafeTransferHelper(caller, owner, recipient, notaId, abi.encode(""));
     }
 
     function testSafeTransferOperator() public {
@@ -38,7 +38,7 @@ contract SafeTransferTest is BaseRegistrarTest {
         
         vm.prank(owner);
         REGISTRAR.setApprovalForAll(caller, true);
-        _registrarSafeTransferHelper(caller, owner, recipient, notaId);
+        _registrarSafeTransferHelper(caller, owner, recipient, notaId, abi.encode(""));
     }
 
     function testSafeTransferFailUnauthorized(address unauthorized) public {
@@ -59,14 +59,7 @@ contract SafeTransferTest is BaseRegistrarTest {
         REGISTRAR.safeTransferFrom(owner, address(contractAddr), notaId);
     }
 
-    function testFuzzSafeTransfer(address to) public {
-        vm.assume(to != address(0));
-        vm.assume(!_isContract(to));
-        _registrarTransferAssumptions(owner, owner, to, notaId);
-        _registrarSafeTransferHelper(owner, owner, to, notaId);
-    }
-
-    function testFuzzSafeTransferWithData(address to, bytes calldata testData) public {
+    function testFuzzSafeTransfer(address to, bytes calldata testData) public {
         bytes memory data;
         if (testData.length == 0){
             data = abi.encode("");
@@ -77,6 +70,6 @@ contract SafeTransferTest is BaseRegistrarTest {
         vm.assume(to != address(0));
         vm.assume(!_isContract(to));
         _registrarTransferAssumptions(owner, owner, to, notaId);
-        _registrarSafeTransferWithDataHelper(owner, owner, to, notaId, data);
+        _registrarSafeTransferHelper(owner, owner, to, notaId, data);
     }
 }

--- a/test/TokenURI.t.sol
+++ b/test/TokenURI.t.sol
@@ -1,10 +1,55 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.16;
 
+import "openzeppelin/utils/Base64.sol";
+import "openzeppelin/utils/Strings.sol";
+
 import "./BaseRegistrarTest.t.sol";
 
 contract TokenURITest is BaseRegistrarTest {
+    address public caller = address(0xbeef);
+    address public owner = address(0xdead);
+    uint256 public notaId;
+    uint256 escrowAmount = 1 ether;
+
     function setUp() public override {
         super.setUp();
+        
+        _fundCallerApproveAddress(caller, DAI, 100 ether, address(REGISTRAR));
+        notaId = _registrarWriteHelper(caller, address(DAI), escrowAmount, 0, owner, HOOK, "");
+    }
+
+    function testTokenURI() public {
+        string memory expectedTokenURI = string(
+            abi.encodePacked(
+                "data:application/json;base64,",
+                Base64.encode(
+                    bytes(
+                        abi.encodePacked(
+                            '{"attributes":[{"trait_type":"ERC20","value":"',
+                            Strings.toHexString(address(DAI)),
+                            '"},{"trait_type":"Amount","display_type":"number","value":',
+                            Strings.toString(escrowAmount),
+                            '},{"trait_type":"Hook Contract","value":"',
+                            Strings.toHexString(address(HOOK)),
+                            '"}',
+                            "",
+                            "]",
+                            "",
+                            "}"
+                        )
+                    )
+                )
+            )
+        );
+        
+        assertEq(REGISTRAR.tokenURI(notaId), expectedTokenURI, "Token URI should match the expected URI");
+    }
+
+    function testQueryNonExistentTokenURI() public {
+        uint256 nonExistentNotaId = 999;
+        
+        vm.expectRevert(INotaRegistrar.NonExistent.selector);
+        REGISTRAR.tokenURI(nonExistentNotaId);
     }
 }

--- a/test/Transfer.t.sol
+++ b/test/Transfer.t.sol
@@ -4,7 +4,49 @@ pragma solidity ^0.8.16;
 import "./BaseRegistrarTest.t.sol";
 
 contract TransferTest is BaseRegistrarTest {
+    address public caller = address(0xbeef);
+    address public owner = address(0xdead);
+    address public recipient = address(0xcafe);
+    uint256 public notaId;
+
     function setUp() public override {
         super.setUp();
+        
+        _fundCallerApproveAddress(caller, DAI, 100 ether, address(REGISTRAR));
+        notaId = _registrarWriteHelper(caller, address(DAI), 1 ether, 0, owner, HOOK, "");
+    }
+
+    function testTransfer() public {
+        _registrarTransferAssumptions(owner, owner, recipient, notaId);
+        _registrarTransferHelper(owner, owner, recipient, notaId);
+    }
+
+    function testTransferApproved() public {
+        _registrarApproveHelper(owner, caller, notaId);
+        _registrarTransferHelper(caller, owner, recipient, notaId);
+    }
+
+    function testTransferOperator() public {
+        vm.expectEmit(true, true, true, true);
+        emit IERC721.ApprovalForAll(owner, caller, true);
+        
+        vm.prank(owner);
+        REGISTRAR.setApprovalForAll(caller, true);
+        _registrarTransferHelper(caller, owner, recipient, notaId);
+    }
+
+    function testTransferFailUnauthorized(address unauthorized) public {
+        vm.assume(unauthorized != owner);
+        vm.assume(unauthorized != REGISTRAR.getApproved(notaId));
+        vm.assume(!REGISTRAR.isApprovedForAll(owner, unauthorized));
+
+        vm.expectRevert("NOT_APPROVED_OR_OWNER");
+        vm.prank(unauthorized);
+        REGISTRAR.transferFrom(owner, recipient, notaId);
+    }
+
+    function testFuzzTransfer(address to) public {
+        _registrarTransferAssumptions(owner, owner, to, notaId);
+        _registrarTransferHelper(owner, owner, to, notaId);
     }
 }

--- a/test/Update.sol
+++ b/test/Update.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.16;
+
+import "./BaseRegistrarTest.t.sol";
+
+contract UpdateTest is BaseRegistrarTest {
+    address public caller = address(0xbeef);
+    address public owner = address(0xdead);
+    uint256 public notaId;
+    
+    function setUp() public override {
+        super.setUp();
+        _fundCallerApproveAddress(caller, DAI, 1 ether, address(REGISTRAR));
+        vm.prank(caller);
+        notaId = REGISTRAR.write(address(DAI), 1 ether, 0, owner, HOOK, "");
+    }
+
+    function testUpdate() public {
+        bytes memory hookData = "";
+        vm.prank(owner);
+        _registrarUpdateHelper(owner, notaId, hookData);
+    }
+
+    function testUpdateNonexistentNota() public {
+        uint256 nonexistentNotaId = 999;
+        bytes memory hookData = "";
+
+        vm.expectRevert(INotaRegistrar.NonExistent.selector);
+        REGISTRAR.update(nonexistentNotaId, hookData);
+    }
+
+
+    function testUpdateEmitsMetadataUpdate() public {
+        bytes memory hookData = "";
+
+        vm.expectEmit(true, true, true, true);
+        emit IERC4906.MetadataUpdate(notaId);
+
+        vm.prank(owner);
+        REGISTRAR.update(notaId, hookData);
+    }
+}


### PR DESCRIPTION
This pull request introduces several new test cases and helper functions to improve the coverage and robustness of the `NotaRegistrar` contract. The changes include adding new test contracts for various functionalities such as approval, burning, cashing, funding, hook fees, protocol fees, and safe transfers. Additionally, several helper functions have been added to the `BaseRegistrarTest` to support these new tests.

### New Test Contracts and Functions:
* [`test/Approve.t.sol`](diffhunk://#diff-5f2490a7b34a8746fb30bbbb739fc18312bd55ac6f7a9879fef186b4d3f1d096R7-R47): Added tests for approving tokens, including unauthorized and non-existent token scenarios.
* [`test/Burn.t.sol`](diffhunk://#diff-fa615631908ccda837df8bc47b1c9821f7f92169aa55fea32495ae6040e6d07bR7-R43): Added tests for burning tokens, including by approved addresses and operators.
* [`test/Cash.t.sol`](diffhunk://#diff-e421271789bd2c7651633ac771f803eba34b187b6429d4baa1300e9ce8ccab80R7-R61): Added tests for cashing out tokens, including non-owner and invalid token scenarios.
* [`test/Fund.t.sol`](diffhunk://#diff-63357471d2fb30b4517087c3ec467a3587bb761eacb505c1962b627788a90343R7-R47): Added tests for funding tokens, including with hook fees and insufficient balance scenarios.
* [`test/HookFees.t.sol`](diffhunk://#diff-8d8b47d31787d2b77e12a57eea5726e4c68ece350106ee4f01888e0b0f74c110R7-R31): Added tests for setting hook fees and ensuring only the owner can set them.
* [`test/ProtocolFees.t.sol`](diffhunk://#diff-bc6a040500cdd3135840a76e838c998916b9cc3bfc2bd50bd628bd3671d44b47R10-R25): Added tests for setting protocol fees and ensuring only the owner can set them.
* [`test/SafeTransfer.t.sol`](diffhunk://#diff-9cd797c8847d71804918804942622c88c66e46f5446618f78569ae03ce4d215eR1-R82): Added tests for safe transfers, including with data, by approved addresses, and to non-ERC721Receiver contracts.

### Helper Functions in `BaseRegistrarTest`:
* Added `_registrarSafeTransferHelper` to handle safe transfers with and without additional data. [[1]](diffhunk://#diff-689c07a4f6270fea2574534c3bfe04ebe034813213f6d9ba572a26e1b8200092R190-R275) [[2]](diffhunk://#diff-689c07a4f6270fea2574534c3bfe04ebe034813213f6d9ba572a26e1b8200092L213-R289)
* Added `_registrarBurnHelper` to handle burning tokens and emitting the appropriate events.
* Added `_registrarUpdateHelper` to handle updating tokens and ensuring hook revenue is updated correctly.
* Modified `_fundCallerApproveAddress` to handle different initial allowances and ensure correct approval amounts.
* Updated `_registrarWriteAssumptions` to include additional checks and assumptions for caller and owner addresses.

These changes significantly enhance the test coverage and reliability of the `NotaRegistrar` contract by ensuring various edge cases and scenarios are thoroughly tested.