### PR TITLE
Update burn and update hooks

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -15,10 +15,11 @@ DEPLOY_RPC_URL_LOCAL=127.0.0.1:8545
 deploy-all-local: deploy-factory-local deploy-token-local deploy-registrar-local deploy-hook-local write-local tokenURI-local
 
 deploy-factory-local:
-	forge create --private-key ${PRIVATE_KEY_LOCAL} --rpc-url ${DEPLOY_RPC_URL_LOCAL} src/ImmutableCreate2Factory.sol:ImmutableCreate2Factory --optimizer-runs ${optimizer_runs}
+	forge create src/ImmutableCreate2Factory.sol:ImmutableCreate2Factory \
+	--broadcast --optimizer-runs ${optimizer_runs} --private-key ${PRIVATE_KEY_LOCAL} --rpc-url ${DEPLOY_RPC_URL_LOCAL};
 
 deploy-token-local:
-	forge create --private-key ${PRIVATE_KEY_LOCAL} --rpc-url ${DEPLOY_RPC_URL_LOCAL} test/mock/MockERC20.sol:MockERC20 --constructor-args "Dai" "DAI" 18 --optimizer-runs ${optimizer_runs}
+	forge create test/mock/MockERC20.sol:MockERC20 --broadcast --private-key ${PRIVATE_KEY_LOCAL} --optimizer-runs ${optimizer_runs} --constructor-args "Dai" "DAI" 18 --rpc-url ${DEPLOY_RPC_URL_LOCAL};
 
 # 0.5hrs for 9 zeros base M1 air
 mine-registrar-local:
@@ -31,17 +32,15 @@ mine-registrar-local:
 # Paste this in from the output of the above command if registrar code changes
 salt=0xf39fd6e51aad88f6f4ce6ab8827279cfffb922669edd78cd0fa5eb199a9625d6
 deploy-registrar-local:
-	forge build --optimizer-runs ${optimizer_runs}
-
 	constructorArgs=$$(cast abi-encode "constructor(address)" ${ADDRESS_LOCAL}) ; \
 	constructorArgs=$$(echo $${constructorArgs} | sed 's/0x//') ; \
 	bytecode=$$(jq -r '.bytecode.object' ../out/NotaRegistrar.sol/NotaRegistrar.json)$${constructorArgs} ; \
-	cast send ${FACTORY_ADDRESS_LOCAL} "safeCreate2(bytes32,bytes calldata)" ${salt} $${bytecode} --private-key ${PRIVATE_KEY_LOCAL} --rpc-url ${DEPLOY_RPC_URL_LOCAL};
+	cast send ${FACTORY_ADDRESS_LOCAL} "safeCreate2(bytes32,bytes calldata)" ${salt} $${bytecode} --private-key ${PRIVATE_KEY_LOCAL} -- --broadcast --rpc-url ${DEPLOY_RPC_URL_LOCAL};
 
 # Paste from salt file if registrar code changes
-registrarAddress=0xf403c90302365f14a0e536875d908001cedf1ef5
+registrarAddress=0x1c2c73652ad29eb691169fbc1907268f6703392e
 deploy-hook-local:
-	forge create --private-key ${PRIVATE_KEY_LOCAL} --rpc-url ${DEPLOY_RPC_URL_LOCAL} test/mock/MockHook.sol:MockHook --constructor-args ${registrarAddress} --optimizer-runs ${optimizer_runs}
+	forge create --broadcast --private-key ${PRIVATE_KEY_LOCAL} test/mock/MockHook.sol:MockHook --constructor-args ${registrarAddress} --optimizer-runs ${optimizer_runs}--rpc-url ${DEPLOY_RPC_URL_LOCAL}
 
 writeSelector="write(address,uint256,uint256,address,address,bytes)"
 currency=0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512 # deployed token address
@@ -51,28 +50,29 @@ owner=0x70997970C51812dc3A010C7d01b50e0d17dc79C8 # Send to a different account s
 hook=0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9
 hookData=0x
 write-local:
-	cast send ${currency} "mint(address,uint256)" ${ADDRESS_LOCAL} ${escrow} --private-key ${PRIVATE_KEY_LOCAL} --rpc-url ${DEPLOY_RPC_URL_LOCAL} ; \
-	cast send ${currency} "approve(address,uint256)" ${registrarAddress} ${escrow} --private-key ${PRIVATE_KEY_LOCAL} --rpc-url ${DEPLOY_RPC_URL_LOCAL} ; \
-	cast send ${registrarAddress} ${writeSelector} ${currency} ${escrow} ${instant} ${owner} ${hook} ${hookData} --private-key ${PRIVATE_KEY_LOCAL} --rpc-url ${DEPLOY_RPC_URL_LOCAL}
+	cast send ${currency} "mint(address,uint256)" ${ADDRESS_LOCAL} ${escrow} --private-key ${PRIVATE_KEY_LOCAL} -- --broadcast --rpc-url ${DEPLOY_RPC_URL_LOCAL}; \
+	cast send ${currency} "approve(address,uint256)" ${registrarAddress} ${escrow} --private-key ${PRIVATE_KEY_LOCAL} -- --broadcast --rpc-url ${DEPLOY_RPC_URL_LOCAL}; \
+	cast send ${registrarAddress} ${writeSelector} ${currency} ${escrow} ${instant} ${owner} ${hook} ${hookData} --private-key ${PRIVATE_KEY_LOCAL} -- --broadcast --rpc-url ${DEPLOY_RPC_URL_LOCAL};
 
 tokenURI-local:
-	cast call ${registrarAddress} "tokenURI(uint256)" 1 --private-key ${PRIVATE_KEY_LOCAL} --rpc-url ${DEPLOY_RPC_URL_LOCAL}
+	byteString=$$(cast call ${registrarAddress} "tokenURI(uint256)" 1 --private-key ${PRIVATE_KEY_LOCAL} --rpc-url ${DEPLOY_RPC_URL_LOCAL}); \
+	cast abi-decode "f(bytes)(string)" $${byteString}
 
 # Welcome to the future of programmable crypto payments! Imagine a world where your payments arent just transactions, but smart, programmable assets. From trustless betting to reversibility and multi-step payments, Denotas Nota NFTs revolutionize how you send funds. With Denota, each payment is an NFT, capable of carrying custom rules and data for your unique needs. Theyre not just payments; theyre fully onchain, extensible, composable, and transferable payment agreements. Explore our simple yet powerful payment hooks to deploy your own and start generating revenue!
 # Fully programmable payments with rich metadata for users and a development platform with hooks for developers.
 setURI-local:
 	denotaContractURI="{'name':'Denota Protocol (beta)','description':'The Programmable Escrow Protocol','image':'ipfs://QmZfdTBo6Pnr7qbWg4FSeSiGNHuhhmzPbHgY7n8XrZbQ2v','banner_image':'ipfs://QmVT5v2TGLuvNDcyTv9hjdga2KAnv37yFjJDYsEhGAM2zQ','external_link':'denota.xyz','collaborators':['almaraz.eth']}"; \
-	cast send ${registrarAddress} "setContractURI(string)" "$${denotaContractURI}" --private-key ${PRIVATE_KEY_LOCAL} --rpc-url ${DEPLOY_RPC_URL_LOCAL}
+	cast send ${registrarAddress} "setContractURI(string)" "$${denotaContractURI}" --private-key ${PRIVATE_KEY_LOCAL} --rpc-url ${DEPLOY_RPC_URL_LOCAL}  --broadcast
 
 getURI-local:
-		URI=$$(cast call ${registrarAddress} "contractURI()" --private-key ${PRIVATE_KEY_LOCAL} --rpc-url ${DEPLOY_RPC_URL_LOCAL}) ; \
-		cast abi-decode "f(bytes)(string)" $${URI}
+	URI=$$(cast call ${registrarAddress} "contractURI()" --private-key ${PRIVATE_KEY_LOCAL} --rpc-url ${DEPLOY_RPC_URL_LOCAL}) ; \
+	cast abi-decode "f(bytes)(string)" $${URI}
 
 ######################################################################################################################################################
 #    																	Mainnet																		 #	
 ######################################################################################################################################################
 deploy-registrar:
-	forge compile --optimizer-runs ${optimizer_runs}
+	forge build --optimizer-runs ${optimizer_runs}
 
 	constructorArgs=$$(cast abi-encode "constructor(address)" ${ADDRESS}) ; \
 	constructorArgs=$$(echo $${constructorArgs} | sed 's/0x//') ; \
@@ -82,25 +82,27 @@ deploy-registrar:
 	contractAddress=$$(cat NotaRegistrar.salt.txt | grep "Address: " | awk '{print $$2}') ; 
 	cast send ${FACTORY_ADDRESS} "safeCreate2(bytes32,bytes calldata)" $${salt} $${bytecode} --private-key ${PRIVATE_KEY} --rpc-url ${DEPLOY_RPC_URL};
 
+# TODO make chainId dynamic
 verify-registrar:
+	contractAddress=$$(cat NotaRegistrar.salt.txt | grep "Address: " | awk '{print $$2}') ; \
 	constructorArgs=$$(cast abi-encode "constructor(address)" ${ADDRESS}) ; \
 	constructorArgs=$$(echo $${constructorArgs} | sed 's/0x//') ; \
 	forge verify-contract --num-of-optimizations ${optimizer_runs} --compiler-version v0.8.24 --watch \
 	--constructor-args $${constructorArgs} \
-	--chain-id 11155111 --verifier-url ${VERIFIER_URL} --etherscan-api-key ${ETHER_SCAN_API_KEY} \
-	0x00002bCC9B3e92a59207C43631f3b407AE5bBd0B \
+	--chain-id 137 --verifier-url ${VERIFIER_URL} --etherscan-api-key ${ETHER_SCAN_API_KEY} \
+	$${contractAddress} \
 	src/NotaRegistrar.sol:NotaRegistrar
 
 # Note: sometimes verification is skipped if block times are slow (testnets)
-deploy-verify:
+deploy-verify-registrar:
 	forge compile --optimizer-runs ${optimizer_runs}
 
 	constructorArgs=$$(cast abi-encode "constructor(address)" ${ADDRESS}) ; \
 	constructorArgs=$$(echo $${constructorArgs} | sed 's/0x//') ; \
 	bytecode=$$(jq -r '.bytecode.object' ../out/NotaRegistrar.sol/NotaRegistrar.json)$${constructorArgs} ; \
 	cast create2 --deployer ${FACTORY_ADDRESS} --init-code $${bytecode} --starts-with 00000000 --caller ${ADDRESS} 2>&1 | tee NotaRegistrar.salt.txt ; \
-	salt=$$(cat src/NotaRegistrar.salt.txt | grep "Salt: " | awk '{print $$2}') ; \
-	contractAddress=$$(cat src/NotaRegistrar.salt.txt | grep "Address: " | awk '{print $$2}') ; \
+	salt=$$(cat NotaRegistrar.salt.txt | grep "Salt: " | awk '{print $$2}') ; \
+	contractAddress=$$(cat NotaRegistrar.salt.txt | grep "Address: " | awk '{print $$2}') ; \
 	cast send ${FACTORY_ADDRESS} "safeCreate2(bytes32,bytes calldata)" $${salt} $${bytecode} --private-key ${PRIVATE_KEY} --rpc-url ${DEPLOY_RPC_URL}; \
 	forge verify-contract --num-of-optimizations ${optimizer_runs} --compiler-version v0.8.24 --watch \
 	--constructor-args $${constructorArgs} \
@@ -109,9 +111,9 @@ deploy-verify:
 	src/NotaRegistrar.sol:NotaRegistrar
 
 setURI:
-	contractAddress=$$(cat src/NotaRegistrar.salt.txt | grep "Address: " | awk '{print $$2}') ; \
-	denotaContractURI="{'name':'Denota Protocol (beta)','description':'The Programmable Escrow Protocol','image':'ipfs://QmZfdTBo6Pnr7qbWg4FSeSiGNHuhhmzPbHgY7n8XrZbQ2v','banner_image':'ipfs://QmVT5v2TGLuvNDcyTv9hjdga2KAnv37yFjJDYsEhGAM2zQ','external_link':'denota.xyz','collaborators':['almaraz.eth']}"; \
-	cast send $${contractAddress} "setContractURI(string)" "${denotaContractURI}"" --private-key ${PRIVATE_KEY} --rpc-url ${DEPLOY_RPC_URL}
+	contractAddress=$$(cat NotaRegistrar.salt.txt | grep "Address: " | awk '{print $$2}') ; \
+	denotaContractURI="{'name':'Denota Protocol (beta)','description':'The Programmable Escrow Protocol','image':'ipfs://QmZfdTBo6Pnr7qbWg4FSeSiGNHuhhmzPbHgY7n8XrZbQ2v','banner_image':'ipfs://QmVT5v2TGLuvNDcyTv9hjdga2KAnv37yFjJDYsEhGAM2zQ','external_link':'denota.xyz'}"; \
+	cast send $${contractAddress} "setContractURI(string)" "${denotaContractURI}" --private-key ${PRIVATE_KEY} --rpc-url ${DEPLOY_RPC_URL}
 
 
 # Polygon addresses

--- a/src/NotaRegistrar.sol
+++ b/src/NotaRegistrar.sol
@@ -135,18 +135,19 @@ contract NotaRegistrar is ERC4906, INotaRegistrar, RegistrarGov, ReentrancyGuard
     }
 
     /// @inheritdoc INotaRegistrar
-    function burn(uint256 notaId) external nonReentrant {
+    function burn(uint256 notaId, bytes calldata data) external nonReentrant {
         Nota memory nota = notaInfo(notaId);
         require(_isApprovedOrOwner(msg.sender, notaId), "NOT_APPROVED_OR_OWNER");
 
         nota.hooks.beforeBurn(
-            IHooks.NotaState(notaId, nota.currency, nota.escrowed, ownerOf(notaId), getApproved(notaId))
+            IHooks.NotaState(notaId, nota.currency, nota.escrowed, ownerOf(notaId), getApproved(notaId)),
+            data
         );
 
         _hookRevenue[nota.hooks][nota.currency] += nota.escrowed;
         delete _notas[notaId];
         _burn(notaId);
-        emit Burned(msg.sender, notaId);
+        emit Burned(msg.sender, notaId, data);
     }
 
     /// @inheritdoc INotaRegistrar

--- a/src/NotaRegistrar.sol
+++ b/src/NotaRegistrar.sol
@@ -162,6 +162,7 @@ contract NotaRegistrar is ERC4906, INotaRegistrar, RegistrarGov, ReentrancyGuard
         _notas[notaId].escrowed -= hookFee;
         _hookRevenue[nota.hooks][nota.currency] += hookFee;
 
+        emit Updated(msg.sender, notaId, hookFee, hookData);
         emit MetadataUpdate(notaId);
     }
 

--- a/src/interfaces/IHooks.sol
+++ b/src/interfaces/IHooks.sol
@@ -32,7 +32,7 @@ interface IHooks {
 
     function beforeApprove(address caller, NotaState calldata nota, address to) external returns (bytes4, uint256);
 
-    function beforeBurn(address caller, NotaState calldata nota) external returns (bytes4);
+    function beforeBurn(address caller, NotaState calldata nota, bytes calldata hookData) external returns (bytes4);
 
     function beforeUpdate(address caller, NotaState calldata nota, bytes calldata hookData) external returns (bytes4, uint256);
 

--- a/src/interfaces/INotaRegistrar.sol
+++ b/src/interfaces/INotaRegistrar.sol
@@ -84,7 +84,8 @@ interface INotaRegistrar {
     /// @notice Emitted when a Nota is burned
     /// @param burner The address of the burner
     /// @param notaId The ID of the Nota
-    event Burned(address indexed burner, uint256 indexed notaId);
+    /// @param hookData Additional data for the hook
+    event Burned(address indexed burner, uint256 indexed notaId, bytes hookData);
 
     /// @notice Error indicating that the Nota does not exist
     error NonExistent();
@@ -160,8 +161,9 @@ interface INotaRegistrar {
     * @notice Burns the Nota's ownership, deletes notaInfo, and moves remaining escrowed funds to the hook's revenue
     * @dev Caller must be the owner or approved the Nota or an operator for the owner. Remaining nota funds are credited to the hook's revenue
     * @param notaId The ID of the Nota to burn
+    * @param hookData Additional data for the hook
     */
-    function burn(uint256 notaId) external;
+    function burn(uint256 notaId, bytes calldata hookData) external;
 
     /**
     * @notice Updates the state of a Nota within its hook

--- a/src/interfaces/INotaRegistrar.sol
+++ b/src/interfaces/INotaRegistrar.sol
@@ -87,6 +87,13 @@ interface INotaRegistrar {
     /// @param hookData Additional data for the hook
     event Burned(address indexed burner, uint256 indexed notaId, bytes hookData);
 
+    /// @notice Emitted when a Nota is updated
+    /// @param updater The address of the updater
+    /// @param notaId The ID of the Nota
+    /// @param hookFee The fee taken by the hook
+    /// @param hookData Additional data for the hook
+    event Updated(address indexed updater, uint256 indexed notaId, uint256 hookFee, bytes hookData);
+
     /// @notice Error indicating that the Nota does not exist
     error NonExistent();
 

--- a/src/libraries/Hooks.sol
+++ b/src/libraries/Hooks.sol
@@ -135,9 +135,9 @@ library Hooks {
      * @param self The IHooks contract
      * @param nota The NotaState struct
      */
-    function beforeBurn(IHooks self, IHooks.NotaState memory nota) internal {
+    function beforeBurn(IHooks self, IHooks.NotaState memory nota, bytes calldata hookData) internal {
         (, bytes memory result) =
-            address(self).call(abi.encodePacked(IHooks.beforeBurn.selector, abi.encode(msg.sender, nota)));
+            address(self).call(abi.encodePacked(IHooks.beforeBurn.selector, abi.encode(msg.sender, nota, hookData)));
         if (result.length < 4) revert HookFailure(); // 4 bytes for selector
 
         bytes4 returnedSelector;

--- a/test/Burn.t.sol
+++ b/test/Burn.t.sol
@@ -16,14 +16,18 @@ contract BurnTest is BaseRegistrarTest {
     }
 
     function testBurn() public {
-        _registrarBurnHelper(owner, notaId);
+        _registrarBurnHelper(owner, notaId, "");
+    }
+
+    function testFuzzBurn(bytes calldata hookData) public {
+        _registrarBurnHelper(owner, notaId, hookData);
     }
 
     function testBurnByApproved() public {
         address approved = address(0x1234);
 
         _registrarApproveHelper(owner, approved, notaId);
-        _registrarBurnHelper(approved, notaId);
+        _registrarBurnHelper(approved, notaId, "");
     }
 
     function testBurnByOperator() public {
@@ -32,7 +36,7 @@ contract BurnTest is BaseRegistrarTest {
         vm.prank(owner);
         REGISTRAR.setApprovalForAll(operator, true);
         
-        _registrarBurnHelper(operator, notaId);
+        _registrarBurnHelper(operator, notaId, "");
     }
 
     function testBurnNotOwnerOrApproved() public {
@@ -40,6 +44,6 @@ contract BurnTest is BaseRegistrarTest {
 
         vm.expectRevert("NOT_APPROVED_OR_OWNER");
         vm.prank(notApproved);
-        REGISTRAR.burn(notaId);
+        REGISTRAR.burn(notaId, "");
     }
 }

--- a/test/Update.sol
+++ b/test/Update.sol
@@ -28,15 +28,4 @@ contract UpdateTest is BaseRegistrarTest {
         vm.expectRevert(INotaRegistrar.NonExistent.selector);
         REGISTRAR.update(nonexistentNotaId, hookData);
     }
-
-
-    function testUpdateEmitsMetadataUpdate() public {
-        bytes memory hookData = "";
-
-        vm.expectEmit(true, true, true, true);
-        emit IERC4906.MetadataUpdate(notaId);
-
-        vm.prank(owner);
-        REGISTRAR.update(notaId, hookData);
-    }
 }

--- a/test/mock/MockHook.sol
+++ b/test/mock/MockHook.sol
@@ -60,7 +60,7 @@ contract MockHook is IHooks {
         return (IHooks.beforeApprove.selector, fee);
     }
 
-    function beforeBurn(address, IHooks.NotaState memory) external view returns (bytes4) {
+    function beforeBurn(address, IHooks.NotaState memory, bytes calldata) external view returns (bytes4) {
         if (fail) revert("MockHook: FAIL");
         return IHooks.beforeBurn.selector;
     }


### PR DESCRIPTION
This pull request includes several changes to the `src/Makefile`, `src/NotaRegistrar.sol`, `src/interfaces/INotaRegistrar.sol`, `src/interfaces/IHooks.sol`, `src/libraries/Hooks.sol`, and various test files. The changes primarily focus on enhancing the functionality of the `NotaRegistrar` contract and improving the deployment process.

### Deployment Process Improvements:
* Added `--broadcast` flag to various `forge create` and `cast send` commands to enable broadcasting transactions. [[1]](diffhunk://#diff-3e2513390df543315686d7c85bd901ca9256268970032298815d2f893a9f0685L18-R22) [[2]](diffhunk://#diff-3e2513390df543315686d7c85bd901ca9256268970032298815d2f893a9f0685L34-R43) [[3]](diffhunk://#diff-3e2513390df543315686d7c85bd901ca9256268970032298815d2f893a9f0685L54-R65)
* Modified the `deploy-registrar` target to use `forge build` instead of `forge compile` for consistency.
* Added a `verify-registrar` target to verify the contract on Etherscan with dynamic chain ID.

### Contract Functionality Enhancements:
* Updated the `burn` function in `NotaRegistrar` to accept additional `hookData` parameter and emit the updated `Burned` event with `hookData`. [[1]](diffhunk://#diff-aabadb32674334442376293284a560b6d14c794a16e54fef0d1233fa9df1d39aL138-R150) [[2]](diffhunk://#diff-7d44306c068427c53abd2fb7c74f6c547bfa8988b0d58755f38d7ce4dd571f3bL87-R95) [[3]](diffhunk://#diff-7d44306c068427c53abd2fb7c74f6c547bfa8988b0d58755f38d7ce4dd571f3bR171-R173)
* Added a new `Updated` event to the `INotaRegistrar` interface to capture updates with `hookFee` and `hookData`.
* Modified the `beforeBurn` function in `IHooks` interface to accept `hookData`.

### Test Suite Updates:
* Refactored the `BaseRegistrarTest` to include `hookData` in the `_registrarBurnHelper` and related test functions. [[1]](diffhunk://#diff-689c07a4f6270fea2574534c3bfe04ebe034813213f6d9ba572a26e1b8200092L46-R54) [[2]](diffhunk://#diff-689c07a4f6270fea2574534c3bfe04ebe034813213f6d9ba572a26e1b8200092L188-R189) [[3]](diffhunk://#diff-689c07a4f6270fea2574534c3bfe04ebe034813213f6d9ba572a26e1b8200092L229-R230) [[4]](diffhunk://#diff-689c07a4f6270fea2574534c3bfe04ebe034813213f6d9ba572a26e1b8200092L347-R351) [[5]](diffhunk://#diff-689c07a4f6270fea2574534c3bfe04ebe034813213f6d9ba572a26e1b8200092L358-R363) [[6]](diffhunk://#diff-689c07a4f6270fea2574534c3bfe04ebe034813213f6d9ba572a26e1b8200092L377-R379) [[7]](diffhunk://#diff-689c07a4f6270fea2574534c3bfe04ebe034813213f6d9ba572a26e1b8200092L387-R392)
* Added a new test `testFuzzBurn` to `BurnTest` to test the `burn` function with various `hookData`.

These changes enhance the functionality and flexibility of the `NotaRegistrar` contract and improve the deployment and testing processes.